### PR TITLE
we require torch for GPU-enabled embeddings submodule

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ morfessor==2.0.6
 pyyaml==5.4.1
 pdoc3==0.10.0
 transformers==4.10.0
-# torch==1.9.0
-# torchvision
-# torchaudio
+torch==1.9.0
+torchvision
+torchaudio
 # zs


### PR DESCRIPTION
it may be made optional in the future controlled by install-time flag/argiument